### PR TITLE
Adding missing keyword 'new'.

### DIFF
--- a/gwt-ol3/src/main/java/org/vaadin/gwtol3/client/View.java
+++ b/gwt-ol3/src/main/java/org/vaadin/gwtol3/client/View.java
@@ -15,7 +15,7 @@ public class View extends JavaScriptObject {
     }
 
     public static final native View create()/*-{
-		var view = $wnd.ol.View({});
+		var view = new $wnd.ol.View({});
         return view;
     }-*/;
 


### PR DESCRIPTION
I've added the 'new' keyword, because the method View.create doesn't work without it.