### PR TITLE
Added condition to SelectInteraction

### DIFF
--- a/gwt-ol3/src/main/java/org/vaadin/gwtol3/client/interaction/SelectInteractionOptions.java
+++ b/gwt-ol3/src/main/java/org/vaadin/gwtol3/client/interaction/SelectInteractionOptions.java
@@ -45,4 +45,30 @@ public class SelectInteractionOptions extends JavaScriptObject {
     public final native void setActive(boolean active) /*-{
         this.active = active;
     }-*/;
+    
+    public final native void setCondition(String condition) /*-{
+	    if (condition === "altKeyOnly") {
+	        this.condition = $wnd.ol.events.condition.altKeyOnly;
+	    } else if (condition === "altShiftKeysOnly") {
+	        this.condition = $wnd.ol.events.condition.altShiftKeysOnly;
+	    } else if (condition === "always") {
+	        this.condition = $wnd.ol.events.condition.always;
+	    } else if (condition === "never") {
+	        this.condition = $wnd.ol.events.condition.never;
+	    } else if (condition === "pointerMove") {
+	        this.condition = $wnd.ol.events.condition.pointerMove;
+	    } else if (condition === "singleClick") {
+	        this.condition = $wnd.ol.events.condition.singleClick;
+	    } else if (condition === "noModifierKeys") {
+	        this.condition = $wnd.ol.events.condition.noModifierKeys;
+	    } else if (condition === "platformModifierKeyOnly") {
+	        this.condition = $wnd.ol.events.condition.platformModifierKeyOnly;
+	    } else if (condition === "shiftKeyOnly") {
+	        this.condition = $wnd.ol.events.condition.shiftKeyOnly;
+	    } else if (condition === "targetNotEditable") {
+	        this.condition = $wnd.ol.events.condition.targetNotEditable;
+	    } else if (condition === "mouseOnly") {
+	        this.condition = $wnd.ol.events.condition.mouseOnly;
+	    }
+	}-*/;
 }

--- a/v-ol3/src/main/java/org/vaadin/addon/vol3/client/interaction/OLSelectInteractionConnector.java
+++ b/v-ol3/src/main/java/org/vaadin/addon/vol3/client/interaction/OLSelectInteractionConnector.java
@@ -42,6 +42,9 @@ public class OLSelectInteractionConnector extends OLInteractionConnector impleme
     private SelectInteraction createInteraction(){
         SelectInteractionOptions opts=SelectInteractionOptions.create();
         opts.setStyles(OLStyleConverter.convert(getState().featureStyles));
+        if (getState().condition != null) {
+            opts.setCondition(getState().condition.toString());
+        }
         if(getState().layers!=null){
             JsArray<Layer> layers=JsArray.createArray().cast();
             for(Connector layerConnector : getState().layers){

--- a/v-ol3/src/main/java/org/vaadin/addon/vol3/client/interaction/OLSelectInteractionState.java
+++ b/v-ol3/src/main/java/org/vaadin/addon/vol3/client/interaction/OLSelectInteractionState.java
@@ -10,6 +10,8 @@ import java.util.List;
  * Shared state for the select interaction
  */
 public class OLSelectInteractionState extends AbstractComponentState{
+	// The selection condition 
+	public String condition;
     // Style for selected features
     public List<OLStyle> featureStyles;
     // Layers where the selection is enabled. If not specified, all visible layers are available for selection.

--- a/v-ol3/src/main/java/org/vaadin/addon/vol3/interaction/OLSelectInteraction.java
+++ b/v-ol3/src/main/java/org/vaadin/addon/vol3/interaction/OLSelectInteraction.java
@@ -33,6 +33,7 @@ public class OLSelectInteraction extends OLInteraction {
                 getState().layers=new ArrayList<Connector>();
                 getState().layers.addAll(options.getLayers());
             }
+            getState().condition = options.getCondition();
             getState().featureStyles=options.getStyles();
         }
         this.registerRpc(new OLSelectInteractionSRPCImpl(), OLSelectInteractionSRPC.class);

--- a/v-ol3/src/main/java/org/vaadin/addon/vol3/interaction/OLSelectInteractionOptions.java
+++ b/v-ol3/src/main/java/org/vaadin/addon/vol3/interaction/OLSelectInteractionOptions.java
@@ -9,8 +9,27 @@ import java.util.List;
  * Options for the select interaction
  */
 public class OLSelectInteractionOptions {
+	private String condition;
     private List<OLLayer> layers;
     private List<OLStyle> styles;
+    
+    /** Gets the string specifying the OpenLayers condition that determines when the feature selection changes
+     * 
+     * @return
+     */
+    public String getCondition() {
+    	return condition;
+    }
+    
+    /** Sets the OpenLayers condition that determines when the feature selection changes. 
+     * 
+     * @param condition The name of the OpenLayers condition (eg altKeyOnly, pointerMove, etc)
+     * @return
+     */
+    public OLSelectInteractionOptions setCondition(String condition) {
+    	this.condition = condition;
+    	return this;
+    }
 
     /** Gets the layers where selections can be made.
      *


### PR DESCRIPTION
The OLSelectInteraction now supports the setting of the condition for
the OpenLayers select (eg setting the condition to "pointMove" to create
a hovering interaction.

Signed-off-by: Robert Smith <smithr@ornl.gov>